### PR TITLE
Update the run_a11y_tests.sh to use the new a11y build key

### DIFF
--- a/run_a11y_tests.sh
+++ b/run_a11y_tests.sh
@@ -2,4 +2,4 @@
 sbt -mem 8192 \
   -Dbrowser=remote-chrome \
   -Denvironment=service-manager \
-  acceptance:test
+  a11y:test


### PR DESCRIPTION
Something small we missed while upgrading the sbt-accessibility-linter plugin.