### PR TITLE
DL-7168 welsh file and remove ServiceHeaderName for Safety and Security

### DIFF
--- a/conf/services/safety-and-security-subscription.cy.yml
+++ b/conf/services/safety-and-security-subscription.cy.yml
@@ -1,0 +1,24 @@
+serviceName: Ymrestru ar gyfer Diogelwch
+serviceDescription: |
+  Mae’r gwasanaeth yn caniatáu i ddefnyddiwr ymrestru ar gyfer y gwasanaeth Diogelwch (S&S GB)
+  fel y gall gyflwyno Datganiadau Cryno Wrth Gyrraedd (a elwir weithiau yn ENS).
+serviceDomain: www.tax.service.gov.uk
+serviceUrl: /safety-and-security-subscription
+contactFrontendServiceId: safety-and-security-enrol
+complianceStatus: partial
+accessibilityProblems:
+  - Dim digon o gyferbyniad lliw rhwng testun y blaendir a’r cefndir pan fo’r cysylltiad "Allgofnodi" mewn ffocws
+  - Nid yw teitlau’r tudalennau yn rhoi gwybod i’r defnyddiwr pa wybodaeth y gofynnir amdani neu a roddir
+  - Nid yw testun cyswllt penodol yn cyfleu ystyr y cysylltiad
+  - Nid yw rhai botymau’n ymddwyn fel botymau
+  - Problemau dosrannu (Parsing) gyda’r dudalen terfyn amser a allai effeithio ar ddarllenwyr sgrin
+  - Nid yw’r rhagolwg argraffu yn cynnwys unrhyw arddull ar unrhyw dudalen
+  - Mae’r troedyn yn methu logo’r goron
+  - Mae atalnodau llawn mewn cysylltiadau a allai effeithio ar ddarllenwyr sgrin
+milestones:
+  - description: Trwsio’r holl faterion hygyrchedd sy’n weddill a grybwyllir yn yr adran "Pa mor hygyrch yw’r gwasanaeth hwn" uchod.
+    date: 2021-01-31
+serviceLastTestedDate: 2020-12-01
+statementVisibility: public
+statementCreatedDate: 2020-12-08
+statementLastUpdatedDate: 2020-12-08

--- a/conf/services/safety-and-security-subscription.yml
+++ b/conf/services/safety-and-security-subscription.yml
@@ -1,5 +1,4 @@
 serviceName: Enrol with the Safety and Security
-serviceHeaderName: Enrol with the Safety and Security Service
 serviceDescription: |
   The service allows a user to enrol for the Safety and Security (S&S GB) service
   so that they can submit Entry Summary declarations (sometimes called an ENS).


### PR DESCRIPTION
Removing ServiceHeaderName as no longer used or required
Created Welsh version of file with welsh translations which was missing for the safety and security service