### PR TITLE
DDCE-2930 - Update PBIK Accessibility Statement fix date to 31st July

### DIFF
--- a/conf/services/payrolling-benefits-in-kind.cy.yml
+++ b/conf/services/payrolling-benefits-in-kind.cy.yml
@@ -19,23 +19,23 @@ accessibilityProblems:
   -  Nid yw’r negeseuon gwall drwy’r gwasanaeth yn ddisgrifiadol. Gall hyn ei wneud yn anodd i ddefnyddwyr ddeall yr hyn y maent wedi’i wneud o’i le.
 milestones:
   - description: Os ydych yn segur am gyfnod o amser, mae’r gwasanaeth yn eich allgofnodi’n awtomatig heb roi rhybudd na hysbysiad i chi. Nid yw hyn yn bodloni Canllawiau Hygyrchedd Cynnwys y We, fersiwn 2.1 - Timing Adjustable, Re-authenticating and Timeouts.
-    date: 2022-04-30
+    date: 2022-07-31
   - description: Ar rai tudalennau, mae yna destun mewn tabl a all fod yn anodd i ddarllenwyr sgrin ei ddarllen. Er enghraifft, wrth chwilio am gyflogai, gall fod yn anodd deall canlyniadau’r chwilio gan nad yw penynnau’r tabl wedi’u cysylltu â’r cynnwys yn y tabl. Nid yw hyn yn bodloni Canllawiau Hygyrchedd Cynnwys y We, fersiwn 2.1 - Info and Relationships and Meaningful Sequence.
-    date: 2022-04-30
+    date: 2022-07-31
   - description: Ar y dudalen lle rydych yn dewis buddiannau a threuliau, gall defnyddwyr sydd â darllenydd sgrin ei chael hi’n anodd defnyddio’r blychau ticio. Nid yw hyn yn bodloni Canllawiau Hygyrchedd Cynnwys y We, fersiwn 2.1 - Info and relationships.
-    date: 2022-04-30
+    date: 2022-07-31
   - description: Ar y dudalen lle rydych yn chwilio am gyflogai, gall defnyddwyr sydd â darllenydd sgrin ei chael hi’n anodd mynd at y meysydd testun. Nid yw hyn yn bodloni Canllawiau Hygyrchedd Cynnwys y We, fersiwn 2.1 - Info and relationships.
-    date: 2022-04-30
+    date: 2022-07-31
   - description: Ar y dudalen lle rydych yn dileu buddiant neu draul, gall strwythur y dudalen ei gwneud hi’n anodd i ddefnyddwyr sydd â darllenydd sgrin ddeall y cwestiwn. Nid yw hyn yn bodloni Canllawiau Hygyrchedd Cynnwys y We, fersiwn 2.1 - Headings and labels.
-    date: 2022-04-30
+    date: 2022-07-31
   - description:  Ar rai tudalennau, nid yw’r botymau radio wedi’u labelu. Mae hyn yn golygu y gall defnyddwyr sydd â darllenydd sgrin ei chael hi’n anodd dewis y botwm radio cywir. Nid yw hyn yn bodloni Canllawiau Hygyrchedd Cynnwys y We, fersiwn 2.1 - Info and relationships and Name, Role, Value.
-    date: 2022-04-30
+    date: 2022-07-31
   - description:  Ar y dudalen sy’n dangos canlyniadau’r chwilio, mae’r cysylltiad yn ôl yn diflannu wrth i chi lywio gyda’r bysellfwrdd. Mae hyn yn golygu y bydd y sawl sy’n defnyddio bysellfwrdd yn unig yn ei chael hi’n anodd mynd yn ôl i’r dudalen ddiwethaf. Nid yw hyn yn bodloni Canllawiau Hygyrchedd Cynnwys y We, fersiwn 2.1 - Focus Visible.
-    date: 2022-04-30
+    date: 2022-07-31
   - description:  Mae pob un o’r botymau ac ychydig o’r testun yn anodd eu darllen wrth ddefnyddio ffocws y bysellfwrdd. Mae hyn oherwydd nad yw’r cyferbyniad lliw yn ddigon cryf. Nid yw hyn yn bodloni Canllawiau Hygyrchedd Cynnwys y We, fersiwn 2.1 - Non-text Contrast.
-    date: 2022-04-30
+    date: 2022-07-31
   - description:  Nid yw’r negeseuon gwall drwy’r gwasanaeth yn ddisgrifiadol. Gall hyn ei wneud yn anodd i ddefnyddwyr ddeall yr hyn y maent wedi’i wneud o’i le. Nid yw hyn yn bodloni Canllawiau Hygyrchedd Cynnwys y We, fersiwn 2.1 - Error suggestion.
-    date: 2022-04-30
+    date: 2022-07-31
 serviceLastTestedDate: 2020-01-15
 statementVisibility: public
 statementCreatedDate: 2020-09-17

--- a/conf/services/payrolling-benefits-in-kind.yml
+++ b/conf/services/payrolling-benefits-in-kind.yml
@@ -18,23 +18,23 @@ accessibilityProblems:
   -  The error messages throughout the service are not descriptive. This can make it hard for users to understand what they’ve done wrong.
 milestones:
   - description: If you’re inactive for a period of time, the service automatically logs you out without giving you any warning or notification. This fails WCAG 2.1 - Timing Adjustable, Re-authenticating and Timeouts.
-    date: 2022-04-30
+    date: 2022-07-31
   - description: On some pages, there is text in a table that might be difficult for screen readers to read. For example, when searching for an employee it may be difficult to understand the search results as the table headings are not linked to the content in the table. This fails WCAG 2.1 - Info and Relationships and Meaningful Sequence.
-    date: 2022-04-30
+    date: 2022-07-31
   - description: On the page where you choose benefits and expenses, users with screen readers may find it difficult to use the checkboxes. This fails WCAG 2.1 - Info and relationships.
-    date: 2022-04-30
+    date: 2022-07-31
   - description: On the page where you search for an employee, users with screen readers may find it difficult to access the text fields. This fails WCAG 2.1 - Info and relationships.
-    date: 2022-04-30
+    date: 2022-07-31
   - description: On the page where you remove a benefit or expense, the structure of the page may make it difficult for users with screen readers to understand the question. This fails WCAG 2.1 - Headings and labels.
-    date: 2022-04-30
+    date: 2022-07-31
   - description:  On some pages, the radio buttons are unlabelled. This means that users with screen readers may find it difficult to select the correct radio button. This fails WCAG 2.1 - Info and relationships and Name, Role, Value.
-    date: 2022-04-30
+    date: 2022-07-31
   - description:  On the page that shows search results, the back link disappears when you use keyboard navigation. This will mean that keyboard-only users will find it difficult to go back to the last page. This fails WCAG 2.1 - Focus Visible.
-    date: 2022-04-30
+    date: 2022-07-31
   - description:  All of the buttons and some of the text in the service is difficult to read when using keyboard focus. This is because the colour contrast isn’t strong enough. This fails WCAG 2.1 - Non-text Contrast.
-    date: 2022-04-30
+    date: 2022-07-31
   - description:  The error messages throughout the service are not descriptive. This can make it hard for users to understand what they’ve done wrong. This fails WCAG 2.1 - Error suggestion.
-    date: 2022-04-30
+    date: 2022-07-31
 serviceLastTestedDate: 2020-01-15
 statementVisibility: public
 statementCreatedDate: 2020-09-17


### PR DESCRIPTION
# DDCE-2930 - Update PBIK Accessibility Statement fix date to 31st July

English and Welsh pages with the date change highlighted in yellow (by Chrome find text).

<img width="394" alt="English" src="https://user-images.githubusercontent.com/369407/167663226-271d0ca2-326b-4cc0-bca7-0c3f35c81da5.png">



<img width="248" alt="Welsh" src="https://user-images.githubusercontent.com/369407/167663213-f70f93c2-74ed-4e90-90bf-0a60cbbe5867.png">
