### PR TITLE
Draft - update dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,12 +5,12 @@ import uk.gov.hmrc.DefaultBuildSettings.addTestReportOption
 
 val appName = "accessibility-statement-frontend"
 
-val silencerVersion = "1.7.0"
+val silencerVersion = "1.7.9"
 
 lazy val unitTestSettings =
   inConfig(Test)(Defaults.testTasks) ++
     Seq(
-      testOptions in Test := Seq(Tests.Filter(_ startsWith "unit")),
+      Test / testOptions := Seq(Tests.Filter(_ startsWith "unit")),
       addTestReportOption(Test, "test-reports")
     )
 
@@ -18,7 +18,7 @@ lazy val IntegrationTest         = config("it") extend Test
 lazy val integrationTestSettings =
   inConfig(IntegrationTest)(Defaults.testTasks) ++
     Seq(
-      (testOptions in IntegrationTest) := Seq(Tests.Filter(_ startsWith "it")),
+      (IntegrationTest / testOptions) := Seq(Tests.Filter(_ startsWith "it")),
       addTestReportOption(IntegrationTest, "it-test-reports")
     )
 
@@ -27,8 +27,8 @@ lazy val acceptanceTestSettings =
   inConfig(AcceptanceTest)(Defaults.testTasks) ++
     Seq(
       // The following is needed to preserve the -Dbrowser option to the HMRC webdriver factory library
-      fork in AcceptanceTest := false,
-      (testOptions in AcceptanceTest) := Seq(Tests.Filter(_ startsWith "acceptance")),
+      AcceptanceTest / fork := false,
+      (AcceptanceTest / testOptions) := Seq(Tests.Filter(_ startsWith "acceptance")),
       addTestReportOption(AcceptanceTest, "acceptance-test-reports")
     )
 
@@ -38,7 +38,7 @@ lazy val microservice = Project(appName, file("."))
   .configs(AcceptanceTest, IntegrationTest)
   .settings(
     majorVersion := 0,
-    scalaVersion := "2.12.11",
+    scalaVersion := "2.12.15",
     playDefaultPort := 12346,
     libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
     Compile / unmanagedResourceDirectories += baseDirectory.value / "testOnlyConf",
@@ -58,7 +58,7 @@ lazy val microservice = Project(appName, file("."))
       "com.github.ghik" % "silencer-lib" % silencerVersion % Provided cross CrossVersion.full
     ),
     // ***************
-    pipelineStages in Assets := Seq(gzip),
+    Assets / pipelineStages := Seq(gzip),
     unitTestSettings,
     acceptanceTestSettings,
     integrationTestSettings,

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -4,8 +4,8 @@ object AppDependencies {
   private val circeVersion = "0.12.0"
 
   val compile = Seq(
-    "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % "5.16.0",
-    "uk.gov.hmrc" %% "play-frontend-hmrc"         % "3.17.0-play-28",
+    "uk.gov.hmrc" %% "bootstrap-frontend-play-28" % "6.3.0",
+    "uk.gov.hmrc" %% "play-frontend-hmrc"         % "3.22.0-play-28",
     "io.circe"    %% "circe-core"                 % circeVersion,
     "io.circe"    %% "circe-generic"              % circeVersion,
     "io.circe"    %% "circe-parser"               % circeVersion,
@@ -13,13 +13,11 @@ object AppDependencies {
   )
 
   val test = Seq(
-    "uk.gov.hmrc"            %% "bootstrap-test-play-28"  % "5.16.0"  % "test",
-    "org.scalatest"          %% "scalatest"               % "3.2.3"   % "test",
-    "org.scalatestplus"      %% "selenium-3-141"          % "3.2.0.0" % "test",
+    "uk.gov.hmrc"            %% "bootstrap-test-play-28"  % "6.3.0"  % "test",
+    "org.scalatest"          %% "scalatest"               % "3.2.0"   % "test",
     "org.scalatestplus.play" %% "scalatestplus-play"      % "5.1.0"   % "test",
     "org.mockito"            %% "mockito-scala-scalatest" % "1.14.8"  % "test",
     "org.jsoup"               % "jsoup"                   % "1.10.2"  % "test",
-    "uk.gov.hmrc"            %% "webdriver-factory"       % "0.23.0"  % "test",
-    "com.vladsch.flexmark"    % "flexmark-all"            % "0.36.8"  % "test"
+    "uk.gov.hmrc"            %% "webdriver-factory"       % "0.34.0"  % "test"
   )
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.5.8

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,7 +5,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy2", url("https://open.artefact
 
 resolvers += Resolver.typesafeRepo("releases")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.5.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.7.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
@@ -15,4 +15,6 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-gzip" % "1.0.2")
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-accessibility-linter" % "0.17.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-accessibility-linter" % "0.25.0")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-twirl" % "1.5.1")


### PR DESCRIPTION
The webdriver-factory had a no class defined issue when running the tests with 0.35.0, but not with 0.34.0
It could be related to the update of selenium-java in this commit:
https://github.com/hmrc/webdriver-factory/commit/06a877b239eecbf8eb04f3126bfd56da2443676e

Also needed to add the sbt-twirl plugin as there was a NoSuchMethodError when compiling