### PR TITLE
Child Benefit: Update statement post FT1 re-audit

### DIFF
--- a/conf/services/child-benefit.cy.yml
+++ b/conf/services/child-benefit.cy.yml
@@ -12,11 +12,6 @@ statementCreatedDate: 2022-11-14
 statementLastUpdatedDate: 2023-06-15
 ddc: DDC Newcastle
 automatedTestingOnly: false
-automatedTestingDetails: |
-  This service was tested using
-  1. chrome plugin axe DevTools(automated tool) which analyse the accessibility violations for WCAG2.0 and Section 508 compliance.
-  2. screen reader-NVDA.
-  3. HMRC accessibility team has conducted an internal audit on the service, reported few bugs which were fixed and retested.
 complianceStatus: partial
 accessibilityProblems:
   # FT2: Change of Bank

--- a/conf/services/child-benefit.cy.yml
+++ b/conf/services/child-benefit.cy.yml
@@ -6,18 +6,19 @@ note: This is a fully compliant service which has had automated testing and a au
 serviceDomain: www.tax.service.gov.uk
 serviceUrl: /child-benefit
 contactFrontendServiceId: SCA
-complianceStatus: full
-AutomatedTestingOnly: true
-serviceLastTestedDate: 2023-01-31
+serviceLastTestedDate: 2023-06-12
 statementVisibility: public
 statementCreatedDate: 2022-11-14
-statementLastUpdatedDate: 2023-01-31
+statementLastUpdatedDate: 2023-06-15
 ddc: DDC Newcastle
-automatedTestingDetails: This service was tested using 1.chrome plugin axe DevTools(automated tool) which analyse the accessibility violations for WCAG 2.0 and Section 508 compliance .2.screen reader-NVDA. 3. HMRC accessibility team has conducted an internal audit on the service, reported few bugs which were fixed and retested.
+automatedTestingOnly: false
+automatedTestingDetails: |
+  This service was tested using
+  1. chrome plugin axe DevTools(automated tool) which analyse the accessibility violations for WCAG2.0 and Section 508 compliance.
+  2. screen reader-NVDA.
+  3. HMRC accessibility team has conducted an internal audit on the service, reported few bugs which were fixed and retested.
 complianceStatus: partial
 accessibilityProblems:
-  # FT1: View Payments/Proof of Entitlements
-  - Wrth edrych ar y dudalen Gymraeg, mae'r cyfieithiad sydd ei angen ar gyfer cynnwys y dudalen ar goll o'r ffeil ffurfweddu. Nid yw hyn yn bodloni maen prawf llwyddiant 3.1.2 (AA) (Language of parts) Canllawiau Hygyrchedd Cynnwys y We, fersiwn 2.1
   # FT2: Change of Bank
   - Ni fydd defnyddwyr darllenydd sgrin yn gallu adnabod y cwestiynau sydd angen iddynt eu hateb pan fyddant yn llenwi'r meysydd dyddiad a chadarnhau'r cyfeiriad.
   - Ar y dudalen sy'n nodi i ba cyfrif y bydd eich Budd-dal Plant yn cael ei dalu, nid yw'r tablau wedi'u gosod yn gywir felly bydd defnyddwyr darllenydd sgrin yn ei chael hi'n anodd deall eu cynnwys.

--- a/conf/services/child-benefit.yml
+++ b/conf/services/child-benefit.yml
@@ -12,11 +12,6 @@ statementCreatedDate: 2022-11-14
 statementLastUpdatedDate: 2023-06-15
 ddc: DDC Newcastle
 automatedTestingOnly: false
-automatedTestingDetails: |
-  This service was tested using
-  1. chrome plugin axe DevTools(automated tool) which analyse the accessibility violations for WCAG2.0 and Section 508 compliance.
-  2. screen reader-NVDA.
-  3. HMRC accessibility team has conducted an internal audit on the service, reported few bugs which were fixed and retested.
 complianceStatus: partial
 accessibilityProblems:
   # FT2: Change of Bank

--- a/conf/services/child-benefit.yml
+++ b/conf/services/child-benefit.yml
@@ -6,10 +6,10 @@ note: This is a partially compliant service which has had automated testing and 
 serviceDomain: www.tax.service.gov.uk
 serviceUrl: /child-benefit
 contactFrontendServiceId: SCA
-serviceLastTestedDate: 2023-04-17
+serviceLastTestedDate: 2023-06-12
 statementVisibility: public
 statementCreatedDate: 2022-11-14
-statementLastUpdatedDate: 2023-04-24
+statementLastUpdatedDate: 2023-06-15
 ddc: DDC Newcastle
 automatedTestingOnly: false
 automatedTestingDetails: |
@@ -19,8 +19,6 @@ automatedTestingDetails: |
   3. HMRC accessibility team has conducted an internal audit on the service, reported few bugs which were fixed and retested.
 complianceStatus: partial
 accessibilityProblems:
-  # FT1: View Payments/Proof of Entitlements
-  - When viewing the page in Welsh the content on the page is missing the required translations in the configuration file. This fails WCAG 2.1 success criterion 3.1.2 (AA) Language of parts
   # FT2: Change of Bank
   - Screen-reader users will not be able to correctly identify the questions that they need to answer when populating the date fields and confirming the address.
   - On the 'Your Child Benefit is paid into this account' page, the tables have not been set up correctly so screen-reader users will find it difficult to understand the content in them.


### PR DESCRIPTION
The re-audit of Child Benefit's Feature 1: View Payments/Proof of Entitlement.
This feature has been declared compliant so we have remove the issues associated with this feature.
We remain in partial status though as FT2 is still pending update work/re-auditing.

I have also removed the now redundant automatedTestingOnly and associated automatedTestingDetails as we no longer rely just on automated tools and the [README states](https://github.com/hmrc/accessibility-statement-frontend/blob/main/README.md#how-to-add-your-services-accessibility-statement) that these should only be included if automatedTestingOnly is true.