### PR TITLE
More ChB Updates following FT4 audit

### DIFF
--- a/conf/services/child-benefit.cy.yml
+++ b/conf/services/child-benefit.cy.yml
@@ -1,7 +1,7 @@
 serviceName: Budd-dal Plant
 serviceDescription: |
-  Mae’r gwasanaeth Budd-dal Plant digidol hwn yn galluogi hawlwyr i fwrw golwg dros
-  dystiolaeth o’u hawl i Fudd-dal Plant a manylion eu taliadau.
+  Mae’r gwasanaeth hwn yn galluogi hawlwyr i fwrw golwg dros dystiolaeth o’u hawl i Fudd-dal Plant a’u manylion talu.
+  Mae hefyd yn caniatáu iddynt newid y cyfrif maent yn ei ddefnyddio i dderbyn taliadau a rhoi gwybod i CThEF fod person ifanc yn parhau ag addysg amser llawn nad yw’n addysg uwch fel y gallant ymestyn eu taliadau Budd-dal Plant.
 note: This is a fully compliant service which has had automated testing and a audit by HMRC accessibility team.
 serviceDomain: www.tax.service.gov.uk
 serviceUrl: /child-benefit
@@ -14,22 +14,26 @@ ddc: DDC Newcastle
 automatedTestingOnly: false
 complianceStatus: partial
 accessibilityProblems:
+  # Global
+  # Following line applies to FT2 and FT4
+  - Wrth newid i'r fersiwn Gymraeg, mae'n bosibl na fydd defnyddwyr darllenydd sgrin yn gallu adnabod y rhagddodiad 'Error' ar gyfer teitl y dudalen pan fydd y dudalen wedi llwytho, gan nad yw'r rhagddodiad wedi'i gyfieithu.
+  # FT1: Proof of Entitlement/View Payments
   # FT2: Change of Bank
   - Ni fydd defnyddwyr darllenydd sgrin yn gallu adnabod y cwestiynau sydd angen iddynt eu hateb pan fyddant yn llenwi'r meysydd dyddiad a chadarnhau'r cyfeiriad.
   - Ar y dudalen sy'n nodi i ba cyfrif y bydd eich Budd-dal Plant yn cael ei dalu, nid yw'r tablau wedi'u gosod yn gywir felly bydd defnyddwyr darllenydd sgrin yn ei chael hi'n anodd deall eu cynnwys.
-  - Wrth newid i'r fersiwn Gymraeg, mae'n bosibl na fydd defnyddwyr darllenydd sgrin yn gallu adnabod y rhagddodiad 'Error' ar gyfer teitl y dudalen pan fydd y dudalen wedi llwytho, gan nad yw'r rhagddodiad wedi'i gyfieithu.
   - Pan fydd defnyddwyr yn nodi manylion banc anghyson, maent yn cael eu cyfeirio at y dudalen 'Mae'n ddrwg gennym – mae problem gyda'r gwasanaeth' heb eglurhad clir na neges wall benodol.
   # FT4: FTNAE (Full-Time Non-Advanced Education)
   # Translation Pending
 milestones:
+  # Global
+  - description: Wrth edrych ar y dudalen Gymraeg, mae'r cynnwys sydd â chyfieithiad ar gyfer y rhagddodiad 'Error' ar goll o'r ffeil ffurfweddu. Ni fydd teitl y dudalen a fydd yn cael ei chyflwyno i ddefnyddwyr yn cael ei ynganu'n gywir gan ddarllenwyr sgrin. Nid yw hyn yn bodloni maen prawf llwyddiant 3.1.2 (Language of parts) Canllawiau Hygyrchedd Cynnwys y We, fersiwn 2.1.
+    date: 2023-10-31
+  # FT1: Proof of Entitlement/View Payments
   # FT2: Change of Bank
   - description: Mae allwedd ar goll a fyddai'n helpu defnyddwyr darllenydd sgrin i adnabod y cwestiwn. Nid yw hyn yn bodloni maen prawf llwyddiant 1.3.1 (Info and relationships) Canllawiau Hygyrchedd Cynnwys y We, fersiwn 2.1.
     date: 2023-10-31
   - description: Mae pennawd ar goll yn y tabl ar y dudalen 'Caiff eich Budd-dal Plant ei dalu i'r cyfrif hwn' ar goll ac nid oes gan y colofnau benawdau.  Nid yw hyn yn bodloni maen prawf llwyddiant 1.3.1 (Info and relationships) Canllawiau Hygyrchedd Cynnwys y We, fersiwn 2.1.
     date: 2023-10-31
-  - description: Wrth edrych ar y dudalen Gymraeg, mae'r cynnwys sydd â chyfieithiad ar gyfer y rhagddodiad 'Error' ar goll o'r ffeil ffurfweddu. Ni fydd teitl y dudalen a fydd yn cael ei chyflwyno i ddefnyddwyr yn cael ei ynganu'n gywir gan ddarllenwyr sgrin. Nid yw hyn yn bodloni maen prawf llwyddiant 3.1.2 (Language of parts) Canllawiau Hygyrchedd Cynnwys y We, fersiwn 2.1.
-    date: 2023-10-31
   - description: Nid yw'r dilysiad ar gyfer y manylion banc yn arddangos negeseuon gwall penodol. Nid yw hyn yn bodloni maen prawf llwyddiant 3.3.3 (Error suggestion) Canllawiau Hygyrchedd Cynnwys y We, fersiwn 2.1.
     date: 2023-10-31
     # FT4: FTNAE (Full-Time Non-Advanced Education)
-    # Translation Pending

--- a/conf/services/child-benefit.yml
+++ b/conf/services/child-benefit.yml
@@ -1,7 +1,7 @@
 serviceName: Child Benefit
 serviceDescription: |
-  This digital Child Benefit service enables claimants to view their proof of entitlement
-  to Child Benefit and their payment details.
+  This service enables claimants to view their proof of entitlement for Child Benefit and their payment details.
+  It also allows them to change the account they use to receive payments and tell HMRC that a young person is staying in full-time non-advanced education so they can extend their Child Benefit payments.
 note: This is a partially compliant service which has had automated testing and an audit by the HMRC accessibility team.
 serviceDomain: www.tax.service.gov.uk
 serviceUrl: /child-benefit
@@ -14,23 +14,25 @@ ddc: DDC Newcastle
 automatedTestingOnly: false
 complianceStatus: partial
 accessibilityProblems:
+  # Global
+  # Following line applies to FT2 and FT4
+  - When switching to the Welsh version, screen-reader users may not be able to identify the 'Error' prefix for page title when the page has loaded, as it has not been translated.
+  # FT1: Proof of Entitlement/View Payments
   # FT2: Change of Bank
   - Screen-reader users will not be able to correctly identify the questions that they need to answer when populating the date fields and confirming the address.
   - On the 'Your Child Benefit is paid into this account' page, the tables have not been set up correctly so screen-reader users will find it difficult to understand the content in them.
-  - When switching to the Welsh version, screen-reader users may not be able to identify the 'Error' prefix for page title when the page has loaded, as it has not been translated.
   - When users enter mismatching bank details, they are taken to the 'Sorry there is a problem with the service' page without a clear understanding or a specific error message.
   # FT4: FTNAE (Full-Time Non-Advanced Education)
-  - When switching to the Welsh version, screen-reader users may not be able to identify the 'Error' prefix for error messages when the page has loaded, as it has not been translated.
 milestones:
+  # Global
+  - description: When viewing the page in Welsh, the content 'Error' prefix translation is missing in the configuration file. The error message presented to users will not be correctly pronounced by screen readers. This fails WCAG 2.1 success criterion 3.1.2 Language of parts
+    date: 2023-10-31
+  # FT1: Proof of Entitlement/View Payments
   # FT2: Change of Bank
   - description: There is a missing legend that would help screen-reader users to identify the  question. This fails WCAG 2.1 success criterion 1.3.1 Info and relationships.
     date: 2023-10-31
   - description: The table on 'Your Child Benefit is paid into this account' page is missing a caption and does not provide column headings. This fails WCAG 2.1 success criterion 1.3.1 Info and relationships.
     date: 2023-10-31
-  - description: When viewing the page in Welsh, the content 'Error' prefix translation is missing in the configuration file. The page title presented to users will not be correctly pronounced by screen readers. This fails WCAG 2.1 success criterion 3.1.2 Language of parts.
-    date: 2023-10-31
   - description: The validation for bank details is not displaying specific error messages. This fails WCAG 2.1 success criterion 3.3.3 Error suggestion.
     date: 2023-10-31
     # FT4: FTNAE (Full-Time Non-Advanced Education)
-  - description: When viewing the page in Welsh, the content 'Error' prefix translation is missing in the configuration file. The error message presented to users will not be correctly pronounced by screen readers. This fails WCAG 2.1 success criterion 3.1.2 Language of parts
-    date: 2023-10-31


### PR DESCRIPTION
* Service description update in both english and welsh
* Normalising the same statement across multiple features
    * We have the same statement for both FT2 and FT4 regarding a piece of copy that needs Welsh but each line appears in the statement so having it under each internally managed feature block means to appears twice on our statement. Moving these to a new internally managed *Global* block along with a note on which features they apply to as the Audit Team will see these as different audit and as such track these separately.