### PR TITLE
DLS-10382: Migrate to accessibility frontend template [CGT]

### DIFF
--- a/conf/services/capital-gains-tax-uk-property.cy.yml
+++ b/conf/services/capital-gains-tax-uk-property.cy.yml
@@ -1,0 +1,16 @@
+serviceName: Treth Enillion Cyfalaf
+serviceHeaderName: Treth Enillion Cyfalaf
+serviceDescription: Gallwch ddefnyddio’r gwasanaeth hwn i roi gwybod am warediad o dir neu eiddo preswyl yn y DU (a wnaed o 6 Ebrill 2020 ymlaen). Gallwch hefyd fwrw golwg dros eich Ffurflenni Treth blaenorol a’r rhai cyfredol.
+serviceDomain: www.tax.service.gov.uk
+serviceUrl: /capital-gains-tax-uk-property
+contactFrontendServiceId: CGTPD
+complianceStatus: full
+serviceLastTestedDate: 2020-05-15
+statementVisibility: public
+statementCreatedDate: 2020-04-06
+statementLastUpdatedDate: 2024-04-29
+businessArea: Customer Strategy & Tax Design (CS&TD)
+ddc: DDC Worthing
+liveOrClassic: Live Services - Worthing
+typeOfService: Live services
+wcagVersion: 2.1 AA

--- a/conf/services/capital-gains-tax-uk-property.yml
+++ b/conf/services/capital-gains-tax-uk-property.yml
@@ -1,0 +1,16 @@
+serviceName: Capital Gains Tax
+serviceHeaderName: Capital Gains Tax
+serviceDescription: You can use this service to report the disposal of UK residential property or land (made from 6 April 2020). You can also view your previous and current returns.
+serviceDomain: www.tax.service.gov.uk
+serviceUrl: /capital-gains-tax-uk-property
+contactFrontendServiceId: CGTPD
+complianceStatus: full
+serviceLastTestedDate: 2020-05-15
+statementVisibility: public
+statementCreatedDate: 2020-04-06
+statementLastUpdatedDate: 2024-04-29
+businessArea: Customer Strategy & Tax Design (CS&TD)
+ddc: DDC Worthing
+liveOrClassic: Live Services - Worthing
+typeOfService: Live services
+wcagVersion: 2.1 AA


### PR DESCRIPTION
It's been discovered that the accessibility statement for cgt-property-disposals-frontend was defined in the repo itself, as opposed to using the accessibility frontend to generate it.

To address that the two new .yml files were added from scratch 

The serviceDescription field was taken from accessibilityStatement.usingThisService.p1 located in the conf/messages file in https://github.com/hmrc/cgt-property-disposals-frontend/blob/811fc232db080270f4bee895c4f3d6f53e09d91f/conf/messages#L197