### PR TITLE
NOJIRA archive unused statement

### DIFF
--- a/conf/services/tax-fraud-reporting-frontend.cy.yml
+++ b/conf/services/tax-fraud-reporting-frontend.cy.yml
@@ -1,4 +1,4 @@
-serviceName: Rhoi gwybod i CThEF am achosion o dwyll treth neu arbed treth
+serviceName: Rhoi gwybod i CThEF am achosion o dwyll treth neu arbed treth sydd wedi’i archifo
 serviceHeaderName: Rhoi gwybod i CThEF am achosion o dwyll treth neu arbed treth
 serviceDescription: |
   Rhowch wybod i CThEF am achosion o dwyll treth neu arbed treth a gyflawnwyd gan fusnes neu unigolyn. Mae’n cymryd tua 10-15 munud i wneud hyn. Ni ofynnir i chi uwchlwytho dogfennau yn yr adroddiad, a chedwir unrhyw wybodaeth a ddarperir yn breifat ac yn gyfrinachol. Gallwch roi gwybod yn ddienw neu roi manylion cyswllt i CThEF, er mwyn i CThEF allu gwneud gwaith dilynol i gael gwybodaeth ategol sydd gennych.
@@ -7,7 +7,7 @@ serviceUrl: /report-tax-fraud
 contactFrontendServiceId: tax-fraud-reporting-frontend    # A unique identifier for your service
 complianceStatus: full
 serviceLastTestedDate: 2022-04-25
-statementVisibility: public
+statementVisibility: archived
 statementCreatedDate: 2022-03-14
 statementLastUpdatedDate: 2022-05-03
 businessArea: Customer Compliance Group (CCG)

--- a/conf/services/tax-fraud-reporting-frontend.yml
+++ b/conf/services/tax-fraud-reporting-frontend.yml
@@ -1,4 +1,4 @@
-serviceName: Report tax fraud or avoidance to HMRC
+serviceName: Archived Report tax fraud or avoidance to HMRC
 serviceHeaderName: Report tax fraud or avoidance to HMRC
 serviceDescription: |
   Report tax fraud or avoidance to HMRC committed by a business or individual, which takes approximately 10-15 minutes to complete. You will not be asked to upload documentation in the report, and any information provided is kept private and confidential. You can report anonymously or provide contact details to HMRC, where HMRC may follow up to obtain supporting information you hold.
@@ -7,7 +7,7 @@ serviceUrl: /report-tax-fraud
 contactFrontendServiceId: tax-fraud-reporting-frontend    # A unique identifier for your service
 complianceStatus: full
 serviceLastTestedDate: 2022-04-25
-statementVisibility: public
+statementVisibility: archived
 statementCreatedDate: 2022-03-14
 statementLastUpdatedDate: 2022-05-03
 businessArea: Customer Compliance Group (CCG)


### PR DESCRIPTION
/report-tax-fraud use their own custom statement because they have extra privacy requirements

I checked this with the owning team, ddcy live services