### PR TITLE
Update hmrc-app

### DIFF
--- a/conf/services/hmrc-android-app.yml
+++ b/conf/services/hmrc-android-app.yml
@@ -6,11 +6,11 @@ serviceDescription: |
 serviceDomain: play.google.com
 serviceUrl: /store/apps/details?id=uk.gov.hmrc.ptcalc&hl=en_GB
 statementType: android
-complianceStatus: full
+complianceStatus: noncompliant
 statementVisibility: public
 serviceLastTestedDate: 2023-05-04
 statementCreatedDate: 2021-06-10
-statementLastUpdatedDate: 2023-06-13
+statementLastUpdatedDate: 2025-07-23
 
 businessArea: Customer Services Group (CSG)
 ddc: DDC Worthing


### PR DESCRIPTION
The mobile app has become non compliant by integrating the child benefit journey which has not been tested for  accessibility 