### PR TITLE
PIL-3159: Update pillar2 accessibility statement to reflect full WCAG 2.2 AA compliance following latest accessibility audit

### DIFF
--- a/conf/services/pillar2.yml
+++ b/conf/services/pillar2.yml
@@ -4,21 +4,11 @@ serviceDescription: |
 serviceDomain: www.tax.service.gov.uk
 serviceUrl: /report-pillar2-top-up-taxes
 contactFrontendServiceId: pillar2-frontend
-complianceStatus: partial
-accessibilityProblems:
-  - On ‘Manage group details’ and ‘Accounting period change successful’, the summary card headings and change links have the same text, making it difficult to tell them apart.
-  - When some of the scrollable tables have focus, there is not enough colour contrast. Some users will not know which element has keyboard focus.
-milestones:
-  - description: |
-      Identical headings and change links. This fails WCAG 2.2 success criterion 2.4.4: Link purpose (in context) and 2.4.6: Headings and Labels.
-    date: 2026-07-31
-  - description: |
-      The colour of the keyboard focus used for some of the scrollable tables does not meet the required contrast ratio. This fails WCAG 2.2 success criterion 1.4.11 Non-text Contrast.
-    date: 2026-07-31
-serviceLastTestedDate: 2026-06-03
+complianceStatus: full
+serviceLastTestedDate: 2026-07-17
 statementVisibility: public
 statementCreatedDate: 2024-04-29
-statementLastUpdatedDate: 2026-06-16
+statementLastUpdatedDate: 2026-07-22
 businessArea: Customer Compliance Group (CCG)
 ddc: DDC Newcastle
 liveOrClassic:

--- a/conf/services/pillar2.yml
+++ b/conf/services/pillar2.yml
@@ -1,6 +1,6 @@
-serviceName: Report Pillar 2 top-up taxes
+serviceName: Report Pillar 2 Top-up Taxes
 serviceDescription: |
-  Report Pillar 2 top-up taxes is a digital service whereby groups with a turnover of €750m or more can register and subscribe to the tax service and enable compliance to the global tax policy.
+  Report Pillar 2 Top-up Taxes is a digital service whereby groups with a turnover of €750m or more can register and subscribe to the tax service and enable compliance to the global tax policy.
 serviceDomain: www.tax.service.gov.uk
 serviceUrl: /report-pillar2-top-up-taxes
 contactFrontendServiceId: pillar2-frontend


### PR DESCRIPTION
Updated Pillar 2 Accessibility Statement to reflect latest accessibility audit:

The Digital Accessibility team conducted a WCAG 2.2 AA accessibility audit second retest of updates made to the service Pillar 2 Top-up Taxes during the week commencing Monday 6 July 2026 and week commencing Monday 13 July 2026.
All previously reported WCAG 2.2 level A and AA issues have been fixed and the 1 new WCAG issue identified during this second retest was fixed and verified as fixed during this second retest.
Under the Regulations to make public sector websites and mobile applications accessible this service can publish a fully compliant WCAG 2.2 AA accessibility statement.